### PR TITLE
Handle missing Firebase configuration gracefully

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,12 @@
 import { useEffect } from 'react';
 import { signInWithPopup } from 'firebase/auth';
 import { useRouter } from 'next/navigation';
-import { appleProvider, firebaseAuth, googleProvider } from '@/lib/firebase/client';
+import {
+  appleProvider,
+  firebaseAuth,
+  getFirebaseConfigErrorMessage,
+  googleProvider
+} from '@/lib/firebase/client';
 import { useAuth } from '@/components/auth-provider';
 
 export default function HomePage() {
@@ -17,10 +22,20 @@ export default function HomePage() {
   }, [user, loading, router]);
 
   const handleGoogleSignIn = async () => {
+    if (!firebaseAuth) {
+      console.error(getFirebaseConfigErrorMessage() ?? 'Firebase Auth is not configured.');
+      return;
+    }
+
     await signInWithPopup(firebaseAuth, googleProvider);
   };
 
   const handleAppleSignIn = async () => {
+    if (!firebaseAuth) {
+      console.error(getFirebaseConfigErrorMessage() ?? 'Firebase Auth is not configured.');
+      return;
+    }
+
     await signInWithPopup(firebaseAuth, appleProvider);
   };
 
@@ -37,17 +52,25 @@ export default function HomePage() {
         </div>
         <div className="space-y-4">
           <button
-            className="w-full rounded-xl bg-accent py-3 text-white font-medium transition hover:bg-violet-600"
+            className="w-full rounded-xl bg-accent py-3 text-white font-medium transition hover:bg-violet-600 disabled:cursor-not-allowed disabled:opacity-60"
+            disabled={!firebaseAuth}
             onClick={handleGoogleSignIn}
           >
             Se connecter avec Google
           </button>
           <button
-            className="w-full rounded-xl border border-slate-300 py-3 font-medium text-text transition hover:bg-slate-100"
+            className="w-full rounded-xl border border-slate-300 py-3 font-medium text-text transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
+            disabled={!firebaseAuth}
             onClick={handleAppleSignIn}
           >
             Se connecter avec Apple
           </button>
+          {!firebaseAuth && (
+            <p className="text-sm text-red-500">
+              {getFirebaseConfigErrorMessage() ??
+                "La configuration Firebase est manquante. Ajoutez les variables d'environnement requises."}
+            </p>
+          )}
         </div>
       </div>
     </main>

--- a/src/components/auth-provider.tsx
+++ b/src/components/auth-provider.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, useContext, useEffect, useState } from 'react';
 import { onAuthStateChanged, User } from 'firebase/auth';
-import { firebaseAuth } from '@/lib/firebase/client';
+import { firebaseAuth, getFirebaseConfigErrorMessage } from '@/lib/firebase/client';
 
 interface AuthContextValue {
   user: User | null;
@@ -16,6 +16,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    if (!firebaseAuth) {
+      console.error(getFirebaseConfigErrorMessage() ?? 'Firebase Auth is not configured.');
+      setLoading(false);
+      return;
+    }
+
     const unsubscribe = onAuthStateChanged(firebaseAuth, (firebaseUser) => {
       setUser(firebaseUser);
       setLoading(false);

--- a/src/lib/firebase/client.ts
+++ b/src/lib/firebase/client.ts
@@ -1,21 +1,67 @@
-import { initializeApp, getApps, getApp } from 'firebase/app';
+import type { FirebaseApp } from 'firebase/app';
+import { initializeApp, getApps, getApp, type FirebaseOptions } from 'firebase/app';
+import type { Auth } from 'firebase/auth';
 import { getAuth, GoogleAuthProvider, OAuthProvider } from 'firebase/auth';
+import type { Firestore } from 'firebase/firestore';
 import { getFirestore } from 'firebase/firestore';
+import type { FirebaseStorage } from 'firebase/storage';
 import { getStorage } from 'firebase/storage';
 
-const firebaseConfig = {
-  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
-  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
-  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
-  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
-  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID
-};
+const requiredEnvVars = [
+  'NEXT_PUBLIC_FIREBASE_API_KEY',
+  'NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN',
+  'NEXT_PUBLIC_FIREBASE_PROJECT_ID',
+  'NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET',
+  'NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID',
+  'NEXT_PUBLIC_FIREBASE_APP_ID'
+] as const;
 
-const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
+const missingEnvVars = requiredEnvVars.filter((key) => !process.env[key]);
 
-export const firebaseAuth = getAuth(app);
+if (missingEnvVars.length && process.env.NODE_ENV !== 'production') {
+  console.warn(
+    `Firebase is not configured. Missing environment variables: ${missingEnvVars.join(', ')}`
+  );
+}
+
+let firebaseApp: FirebaseApp | undefined;
+
+if (!missingEnvVars.length) {
+  const firebaseConfig: FirebaseOptions = {
+    apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY!,
+    authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN!,
+    projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID!,
+    storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET!,
+    messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID!,
+    appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID!
+  };
+
+  firebaseApp = getApps().length ? getApp() : initializeApp(firebaseConfig);
+}
+
+export const firebaseAuth: Auth | undefined = firebaseApp ? getAuth(firebaseApp) : undefined;
 export const googleProvider = new GoogleAuthProvider();
 export const appleProvider = new OAuthProvider('apple.com');
-export const firestore = getFirestore(app);
-export const storage = getStorage(app);
+export const firestore: Firestore | undefined = firebaseApp
+  ? getFirestore(firebaseApp)
+  : undefined;
+export const storage: FirebaseStorage | undefined = firebaseApp
+  ? getStorage(firebaseApp)
+  : undefined;
+
+export const isFirebaseConfigured = !!firebaseApp;
+
+export const getFirebaseConfigErrorMessage = () =>
+  missingEnvVars.length
+    ? `Firebase is not configured. Missing environment variables: ${missingEnvVars.join(', ')}`
+    : undefined;
+
+export const ensureFirebaseConfigured = () => {
+  if (!firebaseApp) {
+    throw new Error(
+      getFirebaseConfigErrorMessage() ?? 'Firebase is not configured. Environment variables missing.'
+    );
+  }
+
+  return firebaseApp;
+};

--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -11,7 +11,7 @@ import {
   updateDoc,
   where
 } from 'firebase/firestore';
-import { firestore } from './firebase/client';
+import { firestore, getFirebaseConfigErrorMessage } from './firebase/client';
 import type { Course } from '@/types/course';
 import type { Summary } from '@/types/summary';
 import type { Quiz } from '@/types/quiz';
@@ -20,8 +20,20 @@ import type { LeaderboardEntry } from '@/types/user';
 const toMillis = (timestamp: Timestamp | null | undefined) =>
   timestamp ? timestamp.toMillis() : Date.now();
 
+const getFirestoreOrThrow = () => {
+  if (!firestore) {
+    throw new Error(
+      getFirebaseConfigErrorMessage() ??
+        'Firestore is not configured. Please ensure Firebase environment variables are set.'
+    );
+  }
+
+  return firestore;
+};
+
 export async function createCourse(data: Omit<Course, 'id' | 'createdAt' | 'updatedAt'>) {
-  const ref = await addDoc(collection(firestore, 'courses'), {
+  const db = getFirestoreOrThrow();
+  const ref = await addDoc(collection(db, 'courses'), {
     ...data,
     createdAt: serverTimestamp(),
     updatedAt: serverTimestamp()
@@ -31,15 +43,17 @@ export async function createCourse(data: Omit<Course, 'id' | 'createdAt' | 'upda
 }
 
 export async function updateCourse(courseId: string, data: Partial<Course>) {
-  await updateDoc(doc(firestore, 'courses', courseId), {
+  const db = getFirestoreOrThrow();
+  await updateDoc(doc(db, 'courses', courseId), {
     ...data,
     updatedAt: serverTimestamp()
   });
 }
 
 export async function listCourses(userId: string): Promise<Course[]> {
+  const db = getFirestoreOrThrow();
   const snapshot = await getDocs(
-    query(collection(firestore, 'courses'), where('userId', '==', userId), orderBy('createdAt', 'desc'))
+    query(collection(db, 'courses'), where('userId', '==', userId), orderBy('createdAt', 'desc'))
   );
 
   return snapshot.docs.map((docSnap) => ({
@@ -51,7 +65,8 @@ export async function listCourses(userId: string): Promise<Course[]> {
 }
 
 export async function getCourse(courseId: string): Promise<Course | null> {
-  const docSnap = await getDoc(doc(firestore, 'courses', courseId));
+  const db = getFirestoreOrThrow();
+  const docSnap = await getDoc(doc(db, 'courses', courseId));
 
   if (!docSnap.exists()) return null;
 
@@ -65,7 +80,8 @@ export async function getCourse(courseId: string): Promise<Course | null> {
 }
 
 export async function createSummary(data: Omit<Summary, 'id' | 'createdAt'>) {
-  const ref = await addDoc(collection(firestore, 'summaries'), {
+  const db = getFirestoreOrThrow();
+  const ref = await addDoc(collection(db, 'summaries'), {
     ...data,
     createdAt: serverTimestamp()
   });
@@ -74,8 +90,9 @@ export async function createSummary(data: Omit<Summary, 'id' | 'createdAt'>) {
 }
 
 export async function listSummaries(userId: string): Promise<Summary[]> {
+  const db = getFirestoreOrThrow();
   const snapshot = await getDocs(
-    query(collection(firestore, 'summaries'), where('userId', '==', userId), orderBy('createdAt', 'desc'))
+    query(collection(db, 'summaries'), where('userId', '==', userId), orderBy('createdAt', 'desc'))
   );
 
   return snapshot.docs.map((docSnap) => ({
@@ -86,7 +103,8 @@ export async function listSummaries(userId: string): Promise<Summary[]> {
 }
 
 export async function createQuiz(data: Omit<Quiz, 'id' | 'createdAt'>) {
-  const ref = await addDoc(collection(firestore, 'quizzes'), {
+  const db = getFirestoreOrThrow();
+  const ref = await addDoc(collection(db, 'quizzes'), {
     ...data,
     createdAt: serverTimestamp()
   });
@@ -95,8 +113,9 @@ export async function createQuiz(data: Omit<Quiz, 'id' | 'createdAt'>) {
 }
 
 export async function listQuizzes(userId: string): Promise<Quiz[]> {
+  const db = getFirestoreOrThrow();
   const snapshot = await getDocs(
-    query(collection(firestore, 'quizzes'), where('userId', '==', userId), orderBy('createdAt', 'desc'))
+    query(collection(db, 'quizzes'), where('userId', '==', userId), orderBy('createdAt', 'desc'))
   );
 
   return snapshot.docs.map((docSnap) => ({
@@ -107,7 +126,8 @@ export async function listQuizzes(userId: string): Promise<Quiz[]> {
 }
 
 export async function listLeaderboardEntries(week: string): Promise<LeaderboardEntry[]> {
-  const snapshot = await getDocs(collection(firestore, 'leaderboard', week, 'entries'));
+  const db = getFirestoreOrThrow();
+  const snapshot = await getDocs(collection(db, 'leaderboard', week, 'entries'));
 
   return snapshot.docs
     .map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() as LeaderboardEntry) }))


### PR DESCRIPTION
## Summary
- only initialize the Firebase client when all required environment variables are present and expose clear error helpers
- guard authentication flows to handle missing Firebase configuration without crashing and inform the user in the UI
- add a Firestore accessor that throws a descriptive error when Firebase is not configured

## Testing
- npm run lint *(fails: `next` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e427af3204832abc4a0b30b0104919