### PR TITLE
Soften frosted navbar transparency

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,7 @@ import {
   googleProvider
 } from '@/lib/firebase/client';
 import { useAuth } from '@/components/auth-provider';
+import { Navbar } from '@/components/navbar';
 
 export default function HomePage() {
   const router = useRouter();
@@ -44,11 +45,16 @@ export default function HomePage() {
   }
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center bg-background px-6">
-      <div className="max-w-md w-full space-y-8 p-10 rounded-3xl bg-surface shadow-sm border border-slate-200">
-        <div className="space-y-2 text-center">
-          <h1 className="text-3xl font-semibold text-text">UP Mind</h1>
-          <p className="text-slate-600">Réviser, apprendre et progresser grâce à l’IA, sans distraction.</p>
+    <>
+      <Navbar />
+      <main
+        id="connexion"
+        className="flex min-h-screen flex-col items-center justify-center bg-background px-6 pt-28"
+      >
+        <div className="w-full max-w-md space-y-8 rounded-3xl border border-slate-200 bg-surface p-10 shadow-sm">
+          <div className="space-y-2 text-center">
+            <h1 className="text-3xl font-semibold text-text">UP Mind</h1>
+            <p className="text-slate-600">Réviser, apprendre et progresser grâce à l’IA, sans distraction.</p>
         </div>
         <div className="space-y-4">
           <button
@@ -72,7 +78,8 @@ export default function HomePage() {
             </p>
           )}
         </div>
-      </div>
-    </main>
+        </div>
+      </main>
+    </>
   );
 }

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,0 +1,34 @@
+import Link from 'next/link';
+
+export function Navbar() {
+  return (
+    <header className="sticky top-0 z-50 w-full px-6 pt-6">
+      <div
+        className="relative mx-auto flex w-full max-w-5xl items-center justify-between overflow-hidden rounded-full border border-white/30 bg-white/15 px-6 py-3 shadow-[0_20px_45px_-25px_rgba(15,23,42,0.6)] backdrop-blur-2xl backdrop-saturate-150 transition-colors duration-300 supports-[backdrop-filter]:bg-white/25 before:absolute before:inset-0 before:-z-10 before:bg-[linear-gradient(120deg,rgba(255,255,255,0.25),rgba(148,163,184,0.08))] before:opacity-80 before:content-[''] after:pointer-events-none after:absolute after:inset-px after:-z-10 after:rounded-full after:border after:border-white/40 after:opacity-40 after:content-[''] dark:border-slate-700/40 dark:bg-slate-900/15 dark:supports-[backdrop-filter]:bg-slate-900/25 dark:before:bg-[linear-gradient(120deg,rgba(148,163,184,0.08),rgba(15,23,42,0.45))] dark:before:opacity-90 dark:after:border-slate-700/50"
+      >
+        <Link href="/" className="text-lg font-semibold tracking-tight text-slate-900 dark:text-white">
+          UP Mind
+        </Link>
+        <nav className="hidden items-center gap-8 text-sm font-medium text-slate-700 md:flex dark:text-slate-200">
+          <a className="transition hover:text-slate-900 dark:hover:text-white" href="#features">
+            Fonctionnalités
+          </a>
+          <a className="transition hover:text-slate-900 dark:hover:text-white" href="#avantages">
+            Avantages
+          </a>
+          <a className="transition hover:text-slate-900 dark:hover:text-white" href="#tarifs">
+            Tarifs
+          </a>
+        </nav>
+        <div className="flex items-center gap-3">
+          <a
+            href="#connexion"
+            className="rounded-full bg-slate-900/90 px-4 py-2 text-sm font-semibold text-white shadow-[0_10px_30px_-15px_rgba(15,23,42,0.9)] transition hover:bg-slate-900 dark:bg-white/90 dark:text-slate-900"
+          >
+            Se connecter
+          </a>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["DOM", "DOM.Iterable", "ES2021"],
+    "lib": [
+      "DOM",
+      "DOM.Iterable",
+      "ES2021"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -15,12 +19,32 @@
     "incremental": true,
     "baseUrl": ".",
     "paths": {
-      "@/components/*": ["src/components/*"],
-      "@/app/*": ["src/app/*"],
-      "@/lib/*": ["src/lib/*"],
-      "@/types/*": ["src/types/*"]
-    }
+      "@/components/*": [
+        "src/components/*"
+      ],
+      "@/app/*": [
+        "src/app/*"
+      ],
+      "@/lib/*": [
+        "src/lib/*"
+      ],
+      "@/types/*": [
+        "src/types/*"
+      ]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- tweak the frosted glass navbar styling to increase transparency while keeping the chrome visible
- add saturation and gradient refinements so scrolling content remains readable through the header
- slightly adjust navigation link colors for better contrast on the lighter surface

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e42dbe28b8832aa8196b2242bfbaba