### PR TITLE
Improve landing redirect handling

### DIFF
--- a/src/app/connexion/page.tsx
+++ b/src/app/connexion/page.tsx
@@ -56,6 +56,8 @@ export default function ConnexionPage() {
       } else {
         await signInWithEmailAndPassword(firebaseAuth, email, password);
       }
+
+      router.replace('/app');
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Une erreur est survenue.';
       setError(message);
@@ -78,6 +80,7 @@ export default function ConnexionPage() {
 
     try {
       await signInWithPopup(firebaseAuth, googleProvider);
+      router.replace('/app');
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Une erreur est survenue.';
       setError(message);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,9 @@
-'use client';
-
 import Link from 'next/link';
-import { useEffect } from 'react';
-import { useRouter } from 'next/navigation';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
 
-import { useAuth } from '@/components/auth-provider';
 import { Navbar } from '@/components/navbar';
+import { getCurrentUser } from '@/lib/server-auth';
 
 const HERO_HIGHLIGHTS = [
   'Plans de révision dynamiques qui s’adaptent à votre progression.',
@@ -68,29 +66,15 @@ const TESTIMONIALS = [
   }
 ];
 
-export default function HomePage() {
-  const router = useRouter();
-  const { user, loading } = useAuth();
+export default async function HomePage() {
+  const skipAuth = cookies().get('skip_auth')?.value === '1';
 
-  useEffect(() => {
-    if (!loading && user) {
-      router.replace('/app');
+  if (!skipAuth) {
+    const user = await getCurrentUser();
+
+    if (user) {
+      redirect('/app');
     }
-  }, [router, user, loading]);
-
-  if (loading) {
-    return (
-      <>
-        <Navbar />
-        <main className="flex min-h-screen items-center justify-center bg-gradient-to-b from-white via-white to-slate-100 px-6 dark:from-slate-950 dark:via-slate-950 dark:to-slate-900">
-          <p className="text-sm text-slate-500 dark:text-slate-400">Chargement…</p>
-        </main>
-      </>
-    );
-  }
-
-  if (user) {
-    return null;
   }
 
   return (


### PR DESCRIPTION
## Summary
- convert the public landing page into a server component that redirects authenticated users without hydrating the whole view
- streamline the Google and email authentication flows so they immediately route to the dashboard after a successful sign-in

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e585b01d24832abed5734051764560