### PR TITLE
Redirect Mes fiches navigation to new /app/fiches route

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -6,6 +6,15 @@ const nextConfig = {
   reactStrictMode: true,
   experimental: {
     appDir: true
+  },
+  async redirects() {
+    return [
+      {
+        source: '/app/summaries',
+        destination: '/app/fiches',
+        permanent: true
+      }
+    ];
   }
 };
 

--- a/src/app/(dashboard)/app/(routes)/fiches/page.tsx
+++ b/src/app/(dashboard)/app/(routes)/fiches/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '../summaries/page';

--- a/src/app/(dashboard)/app/page.tsx
+++ b/src/app/(dashboard)/app/page.tsx
@@ -21,7 +21,7 @@ const quickLinks = [
   {
     label: 'Mes fiches',
     description: 'Retrouvez toutes vos synthèses générées.',
-    href: '/app/summaries'
+    href: '/app/fiches'
   }
 ];
 
@@ -97,7 +97,7 @@ export default async function DashboardPage() {
             </p>
           </div>
           <Link
-            href="/app/summaries"
+            href="/app/fiches"
             className="inline-flex items-center rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-text transition hover:border-accent"
           >
             Voir toutes les fiches

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -100,7 +100,7 @@ export default async function HomePage() {
                       Accéder à mon espace
                     </Link>
                     <Link
-                      href="/app/summaries"
+                      href="/app/fiches"
                       className="rounded-full border border-slate-300 px-6 py-3 text-base font-semibold text-slate-900 transition hover:-translate-y-0.5 hover:border-slate-500 hover:text-slate-700 dark:border-slate-700 dark:text-white dark:hover:border-slate-500"
                     >
                       Ouvrir mes fiches
@@ -216,7 +216,7 @@ export default async function HomePage() {
                 </span>
               </Link>
               <Link
-                href="/app/summaries"
+                href="/app/fiches"
                 className="group flex flex-col gap-3 rounded-3xl border border-white/20 bg-white/5 p-6 text-left transition hover:border-white/40 hover:bg-white/10"
               >
                 <span className="text-sm font-semibold uppercase tracking-wide text-white/70">Révisions</span>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -39,7 +39,7 @@ export function Navbar() {
                 Mon profil
               </Link>
               <Link
-                href="/app/summaries"
+                href="/app/fiches"
                 className="rounded-full bg-slate-900/90 px-4 py-2 text-sm font-semibold text-white shadow-[0_10px_30px_-15px_rgba(15,23,42,0.9)] transition hover:bg-slate-900 dark:bg-white/90 dark:text-slate-900"
               >
                 Mes fiches

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -6,7 +6,7 @@ import { usePathname } from 'next/navigation';
 const navItems = [
   { label: 'Tableau de bord', href: '/app' },
   { label: 'Mes cours', href: '/app/courses' },
-  { label: 'Mes fiches', href: '/app/summaries' },
+  { label: 'Mes fiches', href: '/app/fiches' },
   { label: 'Mes exercices', href: '/app/quizzes' },
   { label: 'Mes amis', href: '/app/friends' },
   { label: 'Mes groupes', href: '/app/groups' },


### PR DESCRIPTION
## Summary
- add an /app/fiches route that reuses the existing summaries page
- update navigation links and CTAs to point to the new path
- redirect legacy /app/summaries requests to /app/fiches for backward compatibility

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6bd3f9c70832aaa6936446ea86c00