### PR TITLE
Fix dark mode background bleed

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,12 +2,32 @@
 @tailwind components;
 @tailwind utilities;
 
+html {
+  min-height: 100%;
+  background-color: var(--color-background);
+}
+
 :root {
-  color-scheme: light;
+  color-scheme: light dark;
+  --color-background: #f9fafb;
+  --color-surface: #ffffff;
+  --color-accent: #7c3aed;
+  --color-text: #1e293b;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    color-scheme: dark;
+    --color-background: #020617;
+    --color-surface: #0f172a;
+    --color-text: #e2e8f0;
+  }
 }
 
 body {
-  @apply bg-background text-text antialiased;
+  @apply antialiased;
+  background-color: var(--color-background);
+  color: var(--color-text);
 }
 
 button {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,10 +8,10 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
-        background: '#F9FAFB',
-        surface: '#FFFFFF',
-        accent: '#7C3AED',
-        text: '#1E293B'
+        background: 'var(--color-background)',
+        surface: 'var(--color-surface)',
+        accent: 'var(--color-accent)',
+        text: 'var(--color-text)'
       }
     }
   },


### PR DESCRIPTION
## Summary
- define shared CSS variables for the design system colors and switch Tailwind to reference them
- apply the background variables to the html/body elements so the dark theme covers the full viewport

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6bd2e6a40832ab8a068bbfefa7201