### PR TITLE
Fix Next.js build issues in landing page

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,6 @@
 import type { Metadata } from 'next';
-import { Inter } from 'next/font/google';
 import './globals.css';
 import { AuthProvider } from '@/components/auth-provider';
-
-const inter = Inter({ subsets: ['latin'] });
 
 export const metadata: Metadata = {
   title: 'UP Mind',
@@ -17,7 +14,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="fr" className="bg-background">
-      <body className={inter.className}>
+      <body className="font-sans antialiased">
         <AuthProvider>{children}</AuthProvider>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -67,7 +67,11 @@ const TESTIMONIALS = [
 
 export default async function HomePage() {
   const skipAuth = cookies().get('skip_auth')?.value === '1';
-  const user = skipAuth ? null : await getCurrentUser();
+  let user = null;
+
+  if (!skipAuth) {
+    user = await getCurrentUser();
+  }
 
   return (
     <>
@@ -220,8 +224,9 @@ export default async function HomePage() {
                   Gérer
                   <span aria-hidden className="transition-transform group-hover:translate-x-1">→</span>
                 </span>
-              </Link>
-              <Link
+              </ScrollReveal>
+              <ScrollReveal
+                as={Link}
                 href="/app/fiches"
                 className="group flex flex-col gap-3 rounded-3xl border border-white/20 bg-white/5 p-6 text-left transition hover:border-white/40 hover:bg-white/10"
               >

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "strict": true,
     "noEmit": true,
     "esModuleInterop": true,
-    "module": "ESNext",
+    "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "resolveJsonModule": true,
     "isolatedModules": true,


### PR DESCRIPTION
## Summary
- avoid ternary await usage and ensure ScrollReveal link wrappers are properly closed on the home page
- remove the remote Inter font dependency in the root layout to prevent build failures without network access
- align the TypeScript configuration with NodeNext module resolution expectations

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6c18c2f18832a953bbe4f9d1a2d58