### PR TITLE
Add branded footer and guide for AI summary generator

### DIFF
--- a/src/app/(dashboard)/app/(routes)/courses/page.tsx
+++ b/src/app/(dashboard)/app/(routes)/courses/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { CourseForm } from '@/components/course-form';
 import { listCoursesServer } from '@/lib/firestore-admin';
 import { getCurrentUser } from '@/lib/server-auth';
@@ -15,11 +16,54 @@ export default async function CoursesPage() {
       </header>
 
       <section className="grid gap-8 lg:grid-cols-[2fr,1fr]">
-        <div className="rounded-3xl border border-slate-200 bg-surface p-8 shadow-sm">
-          <h2 className="text-xl font-semibold text-text">Nouveau cours</h2>
-          <p className="mt-2 text-sm text-slate-600">Collez votre contenu ci-dessous. Les fichiers PDF peuvent être importés via Storage.</p>
-          <div className="mt-6">
-            <CourseForm />
+        <div className="space-y-6">
+          <div className="rounded-3xl border border-slate-200 bg-surface p-8 shadow-sm">
+            <h2 className="text-xl font-semibold text-text">Nouveau cours</h2>
+            <p className="mt-2 text-sm text-slate-600">
+              Collez votre contenu ci-dessous. Les fichiers PDF peuvent être importés via Storage.
+            </p>
+            <div className="mt-6">
+              <CourseForm />
+            </div>
+          </div>
+
+          <div className="rounded-3xl border border-violet-200/60 bg-gradient-to-br from-white via-white to-violet-50 p-8 shadow-sm">
+            <h2 className="text-lg font-semibold text-text">Connecter l’IA et générer vos fiches</h2>
+            <ol className="mt-4 space-y-4 text-sm text-slate-700">
+              <li>
+                <span className="font-semibold text-violet-700">1.&nbsp;Ajoutez votre clé API</span>
+                <p className="mt-1 text-slate-600">
+                  Renseignez <code className="rounded bg-slate-100 px-1 py-0.5 text-xs text-slate-700">AI_API_KEY</code> et
+                  <code className="ml-1 rounded bg-slate-100 px-1 py-0.5 text-xs text-slate-700">AI_API_BASE_URL</code> dans vos variables d’environnement pour relier UP Mind à ChatGPT.
+                </p>
+              </li>
+              <li>
+                <span className="font-semibold text-violet-700">2.&nbsp;Déposez votre cours</span>
+                <p className="mt-1 text-slate-600">
+                  Enregistrez le cours via le formulaire ci-dessus ou importez un fichier PDF depuis Storage. Nous segmentons automatiquement le contenu pour l’IA.
+                </p>
+              </li>
+              <li>
+                <span className="font-semibold text-violet-700">3.&nbsp;Générez vos fiches</span>
+                <p className="mt-1 text-slate-600">
+                  Ouvrez ensuite le <Link href="/app/summaries" className="font-semibold text-violet-700 hover:text-violet-800">Générateur IA</Link> et choisissez le format de fiche souhaité : synthèse, flashcards ou plan révision.
+                </p>
+              </li>
+            </ol>
+            <div className="mt-6 flex flex-wrap gap-3">
+              <Link
+                href="/app/summaries"
+                className="inline-flex items-center justify-center rounded-full bg-violet-600 px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-violet-500"
+              >
+                Accéder au générateur
+              </Link>
+              <Link
+                href="/app/fiches"
+                className="inline-flex items-center justify-center rounded-full border border-violet-200 px-5 py-2 text-sm font-semibold text-violet-700 transition hover:border-violet-300 hover:text-violet-800"
+              >
+                Voir mes fiches IA
+              </Link>
+            </div>
           </div>
         </div>
 
@@ -37,6 +81,11 @@ export default async function CoursesPage() {
                 </li>
               ))}
             </ul>
+            {courses.length === 0 && (
+              <p className="mt-4 text-xs text-slate-500">
+                Dès que vous ajoutez un cours, il apparaît ici avec sa dernière date de mise à jour.
+              </p>
+            )}
           </div>
         </aside>
       </section>

--- a/src/app/(dashboard)/app/(routes)/summaries/page.tsx
+++ b/src/app/(dashboard)/app/(routes)/summaries/page.tsx
@@ -19,8 +19,26 @@ export default async function SummariesPage() {
         <p className="mt-2 text-sm text-slate-600">
           Collez votre cours ci-dessous et laissez l’IA créer une fiche adaptée à votre temps disponible.
         </p>
-        <div className="mt-6">
+        <div className="mt-6 grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,0.75fr)]">
           <SummaryGenerator />
+          <aside className="space-y-4 rounded-3xl border border-violet-200 bg-white/80 p-6 text-sm text-slate-600 shadow-sm dark:border-violet-900/40 dark:bg-slate-900/70 dark:text-slate-300">
+            <h3 className="text-base font-semibold text-text">Comment connecter l’API ChatGPT ?</h3>
+            <ol className="space-y-3 text-sm">
+              <li>
+                <span className="font-medium text-text">1.</span> Ajoutez vos variables <code className="rounded bg-slate-100 px-1 py-0.5 text-xs text-slate-700 dark:bg-slate-800 dark:text-slate-200">IA_API_KEY</code> et
+                <code className="ml-1 rounded bg-slate-100 px-1 py-0.5 text-xs text-slate-700 dark:bg-slate-800 dark:text-slate-200">IA_API_BASE_URL</code> à votre fichier d’environnement.
+              </li>
+              <li>
+                <span className="font-medium text-text">2.</span> Relancez l’application pour prendre en compte les nouvelles clés.
+              </li>
+              <li>
+                <span className="font-medium text-text">3.</span> Collez votre cours ici, cliquez sur « Générer le résumé » et récupérez les trois fiches proposées.
+              </li>
+            </ol>
+            <p>
+              Astuce : variez la longueur de vos cours pour comparer les résumés concis, moyens et développés et choisissez celui qui correspond le mieux à votre session de révision.
+            </p>
+          </aside>
         </div>
       </section>
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import './globals.css';
 import { AuthProvider } from '@/components/auth-provider';
+import { Footer } from '@/components/footer';
 
 export const metadata: Metadata = {
   title: 'UP Mind',
@@ -15,7 +16,12 @@ export default function RootLayout({
   return (
     <html lang="fr" className="bg-background">
       <body className="font-sans antialiased">
-        <AuthProvider>{children}</AuthProvider>
+        <AuthProvider>
+          <div className="flex min-h-screen flex-col">
+            <div className="flex-1">{children}</div>
+            <Footer />
+          </div>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -65,6 +65,24 @@ const TESTIMONIALS = [
   }
 ];
 
+const SUMMARY_STEPS = [
+  {
+    title: '1. Connectez votre API',
+    description:
+      'Ajoutez vos clés IA dans les variables IA_API_KEY et IA_API_BASE_URL pour relier UP Mind à ChatGPT.'
+  },
+  {
+    title: '2. Collez votre cours',
+    description:
+      'Rendez-vous sur la page Fiches IA, déposez votre contenu et lancez la génération automatique.'
+  },
+  {
+    title: '3. Exploitez les fiches',
+    description:
+      'Choisissez le niveau de détail adapté à votre temps de révision et partagez-les à votre équipe.'
+  }
+];
+
 export default async function HomePage() {
   const skipAuth = cookies().get('skip_auth')?.value === '1';
   let user = null;
@@ -110,6 +128,12 @@ export default async function HomePage() {
                     >
                       Ouvrir mes fiches
                     </Link>
+                    <Link
+                      href="/app/summaries"
+                      className="rounded-full border border-violet-400/60 px-6 py-3 text-base font-semibold text-violet-600 transition hover:-translate-y-0.5 hover:border-violet-500 hover:text-violet-700 dark:border-violet-500/60 dark:text-violet-300 dark:hover:border-violet-400 dark:hover:text-violet-200"
+                    >
+                      Générateur IA
+                    </Link>
                   </>
                 ) : (
                   <>
@@ -124,6 +148,12 @@ export default async function HomePage() {
                       className="rounded-full border border-slate-300 px-6 py-3 text-base font-semibold text-slate-900 transition hover:-translate-y-0.5 hover:border-slate-500 hover:text-slate-700 dark:border-slate-700 dark:text-white dark:hover:border-slate-500"
                     >
                       Voir les forfaits
+                    </Link>
+                    <Link
+                      href="/connexion"
+                      className="rounded-full border border-violet-400/60 px-6 py-3 text-base font-semibold text-violet-600 transition hover:-translate-y-0.5 hover:border-violet-500 hover:text-violet-700 dark:border-violet-500/60 dark:text-violet-300 dark:hover:border-violet-400 dark:hover:text-violet-200"
+                    >
+                      Tester le générateur IA
                     </Link>
                   </>
                 )}
@@ -252,6 +282,52 @@ export default async function HomePage() {
                   <span aria-hidden className="transition-transform group-hover:translate-x-1">→</span>
                 </span>
               </ScrollReveal>
+            </div>
+          </div>
+        </ScrollReveal>
+
+        <ScrollReveal
+          as="section"
+          className="relative overflow-hidden bg-gradient-to-br from-violet-50 via-white to-slate-100 py-20 dark:from-slate-950 dark:via-slate-950 dark:to-slate-900"
+        >
+          <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top_left,rgba(139,92,246,0.18),transparent_55%),radial-gradient(circle_at_bottom_right,rgba(236,72,153,0.18),transparent_55%)]" />
+          <div className="mx-auto grid max-w-6xl gap-12 px-6 md:grid-cols-[1.2fr_1fr] md:items-center">
+            <div className="space-y-6">
+              <span className="text-xs font-semibold uppercase tracking-[0.35em] text-violet-500">Connexion IA</span>
+              <h2 className="text-3xl font-semibold text-slate-900 dark:text-white">
+                Connectez UP Mind à l’API ChatGPT en trois étapes
+              </h2>
+              <p className="text-base text-slate-600 dark:text-slate-300">
+                Configurez votre accès, déposez votre cours et obtenez automatiquement trois fiches de révision adaptées à votre temps disponible.
+              </p>
+              <ul className="space-y-5">
+                {SUMMARY_STEPS.map((step) => (
+                  <li key={step.title} className="rounded-3xl border border-violet-100 bg-white/70 p-5 shadow-sm dark:border-violet-900/60 dark:bg-slate-900/60">
+                    <p className="text-sm font-semibold text-slate-900 dark:text-white">{step.title}</p>
+                    <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">{step.description}</p>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div className="space-y-6 rounded-3xl border border-violet-100 bg-white/80 p-8 shadow-lg shadow-violet-500/10 dark:border-violet-900/50 dark:bg-slate-950/70">
+              <h3 className="text-xl font-semibold text-slate-900 dark:text-white">Configuration rapide</h3>
+              <p className="text-sm text-slate-600 dark:text-slate-300">
+                Ajoutez ces variables à votre fichier d’environnement pour activer le générateur de fiches propulsé par ChatGPT :
+              </p>
+              <pre className="rounded-2xl bg-slate-900/90 p-4 text-xs text-violet-100">
+                {`IA_API_KEY="votre_cle_openai"
+IA_API_BASE_URL="https://api.openai.com/v1/your-endpoint"`}
+              </pre>
+              <p className="text-sm text-slate-600 dark:text-slate-300">
+                Une fois l’accès configuré, collez votre cours dans le générateur et laissez l’IA produire vos trois niveaux de fiches.
+              </p>
+              <Link
+                href={user ? '/app/summaries' : '/connexion'}
+                className="inline-flex items-center justify-center rounded-full bg-violet-600 px-6 py-3 text-sm font-semibold text-white shadow-lg transition hover:bg-violet-500"
+              >
+                Accéder au générateur IA
+                <span aria-hidden className="ml-2">→</span>
+              </Link>
             </div>
           </div>
         </ScrollReveal>

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,0 +1,55 @@
+import Link from 'next/link';
+import { Logo } from './logo';
+
+const footerLinks = [
+  { label: 'Fonctionnalités', href: '#features' },
+  { label: 'Avantages', href: '#avantages' },
+  { label: 'Tarifs', href: '/tarifs' },
+  { label: 'Générateur de fiches IA', href: '/app/summaries' }
+];
+
+export function Footer() {
+  const year = new Date().getFullYear();
+
+  return (
+    <footer className="border-t border-slate-200 bg-white py-10 dark:border-slate-800 dark:bg-slate-950">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-6 md:flex-row md:items-start md:justify-between">
+        <div className="space-y-3">
+          <Logo />
+          <p className="max-w-sm text-sm text-slate-500 dark:text-slate-400">
+            La plateforme de révision qui combine intelligence artificielle et coaching pédagogique pour transformer vos cours en
+            fiches mémorables.
+          </p>
+        </div>
+        <div className="flex flex-col gap-3 text-sm text-slate-600 dark:text-slate-300">
+          <span className="font-semibold text-slate-900 dark:text-white">Explorer</span>
+          <nav className="flex flex-col gap-2">
+            {footerLinks.map((link) => (
+              <Link key={link.href} href={link.href} className="transition hover:text-slate-900 dark:hover:text-white">
+                {link.label}
+              </Link>
+            ))}
+          </nav>
+        </div>
+        <div className="space-y-3 text-sm text-slate-600 dark:text-slate-300">
+          <span className="font-semibold text-slate-900 dark:text-white">Support</span>
+          <p>
+            Besoin d’aide pour connecter l’API ChatGPT ? Consultez notre générateur de fiches IA et suivez les étapes indiquées
+            pour configurer vos clés.
+          </p>
+          <Link
+            href="mailto:support@upmind.app"
+            className="inline-flex items-center gap-2 font-medium text-slate-900 transition hover:underline dark:text-white"
+          >
+            Contacter le support
+            <span aria-hidden>→</span>
+          </Link>
+        </div>
+      </div>
+      <div className="mx-auto mt-10 flex w-full max-w-6xl flex-col gap-2 px-6 text-sm text-slate-500 dark:text-slate-400 md:flex-row md:items-center md:justify-between">
+        <p>© {year} UP Mind. Tous droits réservés.</p>
+        <p>Fait avec passion pour booster vos révisions et vos résultats.</p>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/logo.tsx
+++ b/src/components/logo.tsx
@@ -1,0 +1,12 @@
+export function Logo({ className = '' }: { className?: string }) {
+  return (
+    <span className={`inline-flex items-center gap-3 font-semibold ${className}`}>
+      <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-gradient-to-br from-violet-500 to-fuchsia-500 text-sm font-bold uppercase tracking-wide text-white shadow-lg shadow-violet-500/30 dark:shadow-fuchsia-500/20">
+        UP
+      </span>
+      <span className="text-lg tracking-tight text-slate-900 dark:text-white">
+        Mind
+      </span>
+    </span>
+  );
+}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { useAuth } from '@/components/auth-provider';
+import { Logo } from './logo';
 
 export function Navbar() {
   const { user, loading } = useAuth();
@@ -12,7 +13,7 @@ export function Navbar() {
         className="relative mx-auto flex w-full max-w-5xl items-center justify-between overflow-hidden rounded-full border border-white/30 bg-white/15 px-6 py-3 shadow-[0_20px_45px_-25px_rgba(15,23,42,0.6)] backdrop-blur-2xl backdrop-saturate-150 transition-colors duration-300 supports-[backdrop-filter]:bg-white/25 before:absolute before:inset-0 before:-z-10 before:bg-[linear-gradient(120deg,rgba(255,255,255,0.25),rgba(148,163,184,0.08))] before:opacity-80 before:content-[''] after:pointer-events-none after:absolute after:inset-px after:-z-10 after:rounded-full after:border after:border-white/40 after:opacity-40 after:content-[''] dark:border-slate-700/40 dark:bg-slate-900/15 dark:supports-[backdrop-filter]:bg-slate-900/25 dark:before:bg-[linear-gradient(120deg,rgba(148,163,184,0.08),rgba(15,23,42,0.45))] dark:before:opacity-90 dark:after:border-slate-700/50"
       >
         <Link href="/" className="text-lg font-semibold tracking-tight text-slate-900 dark:text-white">
-          UP Mind
+          <Logo className="text-lg" />
         </Link>
         <nav className="hidden items-center gap-8 text-sm font-medium text-slate-700 md:flex dark:text-slate-200">
           <a className="transition hover:text-slate-900 dark:hover:text-white" href="#features">

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -2,11 +2,13 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { Logo } from './logo';
 
 const navItems = [
   { label: 'Tableau de bord', href: '/app' },
   { label: 'Mes cours', href: '/app/courses' },
   { label: 'Mes fiches', href: '/app/fiches' },
+  { label: 'Fiches IA', href: '/app/summaries' },
   { label: 'Mes exercices', href: '/app/quizzes' },
   { label: 'Mes amis', href: '/app/friends' },
   { label: 'Mes groupes', href: '/app/groups' },
@@ -19,7 +21,7 @@ export function Sidebar({ user }: { user: { displayName: string } }) {
   return (
     <aside className="hidden md:flex w-72 flex-col border-r border-slate-200 bg-surface p-6">
       <div className="mb-10 space-y-1">
-        <h2 className="text-2xl font-semibold text-text">UP Mind</h2>
+        <Logo className="text-2xl" />
         <p className="text-sm text-slate-500">Bienvenue, {user.displayName}</p>
       </div>
       <nav className="space-y-2">


### PR DESCRIPTION
## Summary
- introduce a reusable UP Mind logo component and display it in the navigation, sidebar, and new footer
- add a global footer with support messaging, generator link, and all-rights-reserved notice
- enhance the home and summaries pages with clear guidance for configuring the ChatGPT API and accessing the AI summary generator

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6c571c52c832aa21e3a0f63dc13f9